### PR TITLE
fix: make monorepo path configurable via OPENCLAW_REPO_PATH

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "openclaw-dev": {
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/mcp-server-filesystem", "lib/openclaw/src", "lib/openclaw/extensions", "lib/openclaw/docs"],
+      "command": "node",
+      "args": ["-e", "const{spawn}=require('child_process');const r=process.env.OPENCLAW_REPO_PATH||'lib/openclaw';const c=spawn('npx',['-y','@anthropic-ai/mcp-server-filesystem',r+'/src',r+'/extensions',r+'/docs'],{stdio:'inherit',shell:true});c.on('close',code=>process.exit(code||0))"],
       "env": {}
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ This is a Claude Code plugin for developing and working with the OpenClaw platfo
 - Group related changes, no unrelated refactors bundled
 - Use `scripts/committer "<msg>" <file...>` when in the monorepo
 
+## Configuration
+
+- **`OPENCLAW_REPO_PATH`** — Path to the OpenClaw monorepo (default: `lib/openclaw`). Set this in your environment or in `.claude/settings.local.json` under `env` if the monorepo is cloned elsewhere.
+
 ## Verification Gates
 
 - **Dev loop**: `pnpm check`

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const f=process.env.CLAUDE_FILE_PATH||'';if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:'lib/openclaw',stdio:'ignore'})}catch(e){}}\""
+            "command": "node -e \"const{execSync}=require('child_process');const p=require('path');const f=process.env.CLAUDE_FILE_PATH||'';const r=process.env.OPENCLAW_REPO_PATH||'lib/openclaw';if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:r,stdio:'ignore'})}catch(e){}}\""
           }
         ]
       }

--- a/settings.json
+++ b/settings.json
@@ -8,6 +8,7 @@
     "deny": []
   },
   "env": {
+    "OPENCLAW_REPO_PATH": "lib/openclaw",
     "NODE_OPTIONS": "--max-old-space-size=4096"
   }
 }

--- a/skills/build-plugin/SKILL.md
+++ b/skills/build-plugin/SKILL.md
@@ -40,5 +40,7 @@ Scaffold or validate an OpenClaw plugin named `$ARGUMENTS.plugin_name`.
 
 ## Reference
 
-See `lib/openclaw/docs/plugins/building-plugins.md` for the full guide.
-See `lib/openclaw/extensions/` for 100+ examples of existing plugins.
+The monorepo path is configurable via `OPENCLAW_REPO_PATH` (default: `lib/openclaw`).
+
+See `$OPENCLAW_REPO_PATH/docs/plugins/building-plugins.md` for the full guide.
+See `$OPENCLAW_REPO_PATH/extensions/` for 100+ examples of existing plugins.

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -9,7 +9,7 @@ Run the standard OpenClaw dev verification gate.
 
 ## Steps
 
-1. Navigate to the OpenClaw monorepo root.
+1. Navigate to the OpenClaw monorepo root (`OPENCLAW_REPO_PATH`, default: `lib/openclaw`).
 2. Run `pnpm check` — this runs Oxlint and Oxfmt together.
 3. If failures occur, analyze the output and suggest fixes.
 4. If formatting issues are found, suggest running `pnpm format:fix` to auto-fix.

--- a/skills/explore-sdk/SKILL.md
+++ b/skills/explore-sdk/SKILL.md
@@ -9,20 +9,22 @@ arguments:
 
 # Explore OpenClaw Plugin SDK
 
+The monorepo path is configurable via `OPENCLAW_REPO_PATH` (default: `lib/openclaw`).
+
 Search the OpenClaw Plugin SDK to find the right imports, types, and registration methods.
 
 ## Steps
 
-1. Search `lib/openclaw/src/plugin-sdk/` for files matching the query.
+1. Search `$OPENCLAW_REPO_PATH/src/plugin-sdk/` for files matching the query.
 
-2. Search `lib/openclaw/docs/plugins/sdk-overview.md` for the relevant subpath documentation.
+2. Search `$OPENCLAW_REPO_PATH/docs/plugins/sdk-overview.md` for the relevant subpath documentation.
 
 3. If looking for a registration method, check:
-   - `lib/openclaw/docs/plugins/building-plugins.md` for usage examples
-   - `lib/openclaw/docs/plugins/architecture.md` for capability model context
-   - `lib/openclaw/docs/plugins/sdk-entrypoints.md` for entry point patterns
+   - `$OPENCLAW_REPO_PATH/docs/plugins/building-plugins.md` for usage examples
+   - `$OPENCLAW_REPO_PATH/docs/plugins/architecture.md` for capability model context
+   - `$OPENCLAW_REPO_PATH/docs/plugins/sdk-entrypoints.md` for entry point patterns
 
-4. If looking for an existing implementation, search `lib/openclaw/extensions/` for real-world usage.
+4. If looking for an existing implementation, search `$OPENCLAW_REPO_PATH/extensions/` for real-world usage.
 
 5. Report the correct import path, type signature, and a usage example.
 


### PR DESCRIPTION
## Summary
- All components now respect `OPENCLAW_REPO_PATH` environment variable
- Hooks, MCP config, skills, and settings all use the env var with `lib/openclaw` fallback
- Documented in CLAUDE.md Configuration section

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)