### PR TITLE
fix: use execFileSync to handle paths with spaces

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const f=process.env.CLAUDE_FILE_PATH||'';if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:'lib/openclaw',stdio:'ignore'})}catch(e){}}\""
+            "command": "node -e \"const{execFileSync}=require('child_process');const f=process.env.CLAUDE_FILE_PATH||'';if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execFileSync('npx',['oxfmt','--write',f],{cwd:'lib/openclaw',stdio:'ignore'})}catch(e){}}\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Replaces `execSync` with `execFileSync` in PostToolUse hook
- Uses array args instead of string concatenation, avoiding shell quoting issues
- Fixes paths with spaces (common on Windows user profiles)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)