### PR TITLE
fix: MCP launcher with path validation and configurable repo path

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "openclaw-dev": {
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/mcp-server-filesystem", "lib/openclaw/src", "lib/openclaw/extensions", "lib/openclaw/docs"],
+      "command": "node",
+      "args": ["bin/mcp-start.js"],
       "env": {}
     }
   }

--- a/bin/mcp-start.js
+++ b/bin/mcp-start.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const repoPath = process.env.OPENCLAW_REPO_PATH || "lib/openclaw";
+const dirs = ["src", "extensions", "docs"].map((d) => path.join(repoPath, d));
+
+const missing = dirs.filter((d) => !fs.existsSync(d));
+if (missing.length > 0) {
+  console.error(
+    `[openclaw plugin] Warning: missing directories: ${missing.join(", ")}`
+  );
+  console.error(
+    `Set OPENCLAW_REPO_PATH to point to the OpenClaw monorepo root.`
+  );
+}
+
+const existing = dirs.filter((d) => fs.existsSync(d));
+if (existing.length === 0) {
+  console.error("[openclaw plugin] No valid directories found. Exiting.");
+  process.exit(1);
+}
+
+const child = spawn(
+  "npx",
+  ["-y", "@anthropic-ai/mcp-server-filesystem", ...existing],
+  { stdio: "inherit", shell: true }
+);
+
+child.on("close", (code) => process.exit(code || 0));


### PR DESCRIPTION
## Summary
- Adds `bin/mcp-start.js` wrapper that validates directories before starting MCP server
- Respects `OPENCLAW_REPO_PATH` env var (defaults to `lib/openclaw`)
- Warns on missing directories instead of silently serving errors
- Gracefully exits if no valid directories found

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)