### PR TITLE
fix: declare MCP server as local dependency for offline use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "openclaw-claude-code-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Claude Code plugin for OpenClaw development",
+  "dependencies": {
+    "@anthropic-ai/mcp-server-filesystem": "^0.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `package.json` with `@anthropic-ai/mcp-server-filesystem` as a dependency
- Running `npm install` pre-caches the server locally
- Enables use in air-gapped and corporate proxy environments

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)