### PR TITLE
fix: scope PreToolUse hook to TypeScript files only

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check that the file being written does not import from 'src/**' directly (must use 'openclaw/plugin-sdk/<subpath>' for SDK imports). Also check it does not use 'any' type or '@ts-nocheck'. If violations found, respond with 'BLOCK: <reason>'. Otherwise respond 'PASS'."
+            "prompt": "First check the file extension. If the file is NOT a .ts or .tsx file, respond 'PASS' immediately without further analysis. For .ts/.tsx files: check that the file does not import from 'src/**' directly (must use 'openclaw/plugin-sdk/<subpath>' for SDK imports). Also check it does not use 'any' type or '@ts-nocheck'. If violations found, respond with 'BLOCK: <reason>'. Otherwise respond 'PASS'."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Updates prompt to immediately PASS for non-.ts/.tsx files
- Avoids wasting a model turn on JSON, markdown, config files
- Eliminates false positives on non-TypeScript content

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)