### PR TITLE
fix: format JS/JSX/MJS/CJS files in PostToolUse hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const f=process.env.CLAUDE_FILE_PATH||'';if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:'lib/openclaw',stdio:'ignore'})}catch(e){}}\""
+            "command": "node -e \"const{execSync}=require('child_process');const f=process.env.CLAUDE_FILE_PATH||'';const exts=['.ts','.tsx','.js','.jsx','.mjs','.cjs'];if(exts.some(e=>f.endsWith(e))){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:'lib/openclaw',stdio:'ignore'})}catch(e){}}\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Extends file extension check to include `.js`, `.jsx`, `.mjs`, `.cjs`
- Uses array-based extension matching for cleaner logic
- Ensures all JavaScript/TypeScript files get auto-formatted

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)