### PR TITLE
fix: remove NODE_OPTIONS from default settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -6,8 +6,5 @@
       "Grep"
     ],
     "deny": []
-  },
-  "env": {
-    "NODE_OPTIONS": "--max-old-space-size=4096"
   }
 }


### PR DESCRIPTION
## Summary
- Removes `NODE_OPTIONS: "--max-old-space-size=4096"` from default settings
- Avoids conflicts with user's existing NODE_OPTIONS environment
- Users can add it to `.claude/settings.local.json` if they experience memory issues

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)