### PR TITLE
fix: resolve MCP paths relative to plugin root

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "openclaw-dev": {
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/mcp-server-filesystem", "lib/openclaw/src", "lib/openclaw/extensions", "lib/openclaw/docs"],
+      "command": "node",
+      "args": ["bin/mcp-resolve.js"],
       "env": {}
     }
   }

--- a/bin/mcp-resolve.js
+++ b/bin/mcp-resolve.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawn } = require("child_process");
+const path = require("path");
+
+const pluginRoot = path.resolve(__dirname, "..");
+const repoPath = path.resolve(pluginRoot, "lib/openclaw");
+const dirs = ["src", "extensions", "docs"].map((d) => path.resolve(repoPath, d));
+
+const child = spawn(
+  "npx",
+  ["-y", "@anthropic-ai/mcp-server-filesystem", ...dirs],
+  { stdio: "inherit", shell: true }
+);
+
+child.on("close", (code) => process.exit(code || 0));


### PR DESCRIPTION
## Summary
- Adds `bin/mcp-resolve.js` that uses `__dirname` to resolve paths
- MCP server now gets absolute paths regardless of working directory
- Fixes issue where launching Claude Code from a different CWD broke MCP

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)