### PR TITLE
fix: scope PostToolUse formatting to monorepo files only

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const f=process.env.CLAUDE_FILE_PATH||'';if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:'lib/openclaw',stdio:'ignore'})}catch(e){}}\""
+            "command": "node -e \"const{execSync}=require('child_process');const p=require('path');const f=process.env.CLAUDE_FILE_PATH||'';const r=p.resolve('lib/openclaw');if(!p.resolve(f).startsWith(r)){process.exit(0)}if(f.endsWith('.ts')||f.endsWith('.tsx')){try{execSync('npx oxfmt --write '+JSON.stringify(f),{cwd:r,stdio:'ignore'})}catch(e){}}\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Resolves file path and monorepo root to absolute paths
- Skips formatting if the file is outside the monorepo directory
- Prevents applying wrong oxfmt config to external files

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)