### PR TITLE
fix: allow override comments for intentional any/ts-nocheck

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Check that the file being written does not import from 'src/**' directly (must use 'openclaw/plugin-sdk/<subpath>' for SDK imports). Also check it does not use 'any' type or '@ts-nocheck'. If violations found, respond with 'BLOCK: <reason>'. Otherwise respond 'PASS'."
+            "prompt": "First check the file extension. If the file is NOT a .ts or .tsx file, respond 'PASS' immediately. For .ts/.tsx files, check these rules: 1) No imports from 'src/**' directly (must use 'openclaw/plugin-sdk/<subpath>'). 2) No 'any' type UNLESS the line or preceding line has a comment containing 'eslint-disable' or 'openclaw-allow'. 3) No '@ts-nocheck' UNLESS accompanied by a comment containing 'openclaw-allow-ts-nocheck' explaining the reason. If unjustified violations found, respond with 'BLOCK: <reason>'. Otherwise respond 'PASS'."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- PreToolUse hook now recognizes `eslint-disable` and `openclaw-allow` comments
- `@ts-nocheck` allowed with `openclaw-allow-ts-nocheck` justification comment
- Only blocks truly unjustified usage, not intentional prototyping

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)